### PR TITLE
Fix inconsistent variable name in migration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@
    
          - name: Build application
            env:
-             TABRIS_BUILD_KEY: ${{ secrets.TABRIS_IOS_BUILD_KEY }}
+             TABRIS_BUILD_KEY: ${{ secrets.TABRIS_BUILD_KEY }}
            run: |
              tabris build ios --debug --device --verbose
    
@@ -273,7 +273,7 @@ jobs:
 
       - name: Build application
         env:
-          TABRIS_BUILD_KEY: ${{ secrets.TABRIS_IOS_BUILD_KEY }}
+          TABRIS_BUILD_KEY: ${{ secrets.TABRIS_BUILD_KEY }}
         run: |
           tabris build ios --${{ github.event.inputs.build_type }} --device --verbose
 
@@ -365,7 +365,7 @@ This workflow has to be triggered manually on Github. Go to "Actions" tab, selec
 
           - name: Execute build
             env:
-              TABRIS_BUILD_KEY: ${{ secrets.TABRIS_IOS_BUILD_KEY }}
+              TABRIS_BUILD_KEY: ${{ secrets.TABRIS_BUILD_KEY }}
             run: |
               tabris build --release android -- --packageType=bundle
 


### PR DESCRIPTION
The readme specifically states to use the variable `TABRIS_BUILD_KEY`:
https://github.com/eclipsesource/tabris-connect-migration-guide/blob/00da8245356e6ed0564487dfd1109bd100ce9995/README.md#L78
however the workflow file uses the variable `TABRIS_IOS_BUILD_KEY`.  The key is not specific to either platform, so rename all references to `TABRIS_BUILD_KEY`